### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ var createPattern = function(path) {
 
 var initRiot = function(files) {
     var jasminePath = path.dirname(require.resolve('riot'));
-    files.unshift(createPattern(jasminePath + '/../riot.js'));
+    files.unshift(createPattern(jasminePath + '/../../riot.js'));
 };
 
 initRiot.$inject = ['config.files'];


### PR DESCRIPTION
(jasminePath + '/../../riot.js') lands you in riot/lib/riot.js for some reason. This riot.js has a bunch of imports and isn't meant for web so it causes an error. I think you need to go a directory level up to the compiled riot.js for browser.